### PR TITLE
automatedScanType added in curl

### DIFF
--- a/trigger_pentest.sh
+++ b/trigger_pentest.sh
@@ -1,6 +1,7 @@
 
 URL=https://api.getastra.com/webhooks/integrations/ci-cd
-status_code=$(curl -s -o response.txt -w "%{http_code}" --user-agent "Astra Pentest Trigger Script/1.0" --header "Content-Type: application/json" --request POST --data "{\"accessToken\":\"$ASTRA_ACCESS_TOKEN\",\"projectId\":\"$ASTRA_PROJECT_ID\", \"mode\":\"$ASTRA_AUDIT_MODE\"}" $URL)
+ASTRA_SCAN_TYPE="${ASTRA_SCAN_TYPE:-lightning}"
+status_code=$(curl -s -o response.txt -w "%{http_code}" --user-agent "Astra Pentest Trigger Script/1.0" --header "Content-Type: application/json" --request POST --data "{\"accessToken\":\"$ASTRA_ACCESS_TOKEN\",\"projectId\":\"$ASTRA_PROJECT_ID\", \"mode\":\"$ASTRA_AUDIT_MODE\", \"automatedScanType\":\"$ASTRA_SCAN_TYPE\"}" $URL)
 if [[ "$status_code" == "200" ]] ; then
   echo "✅ Astra pentest was successfully started."
   cat response.txt


### PR DESCRIPTION
Adding 'automatedScanType' in curl to start a scan using "ASTRA_SCAN_TYPE" env variable. If "ASTRA_SCAN_TYPE" is not set, "lightning" will be default value.